### PR TITLE
sbf: add section handling

### DIFF
--- a/pkg/sbf/loader/arithmetic.go
+++ b/pkg/sbf/loader/arithmetic.go
@@ -1,0 +1,66 @@
+package loader
+
+import (
+	"math"
+	"math/bits"
+)
+
+func clampAddUint64(x uint64, y uint64) uint64 {
+	z, carry := bits.Add64(x, y, 0)
+	if carry != 0 {
+		return math.MaxUint64
+	}
+	return z
+}
+
+type addrRange struct {
+	min, max uint64
+}
+
+func newAddrRange() addrRange {
+	return addrRange{min: math.MaxUint64, max: 0}
+}
+
+func (a addrRange) len() uint64 {
+	if a.min >= a.max {
+		return 0
+	}
+	return a.max - a.min
+}
+
+/*
+func (a addrRange) contains(addr uint64) bool {
+	if a.len() == 0 {
+		return false
+	}
+	return a.min <= addr && addr < a.max
+}
+*/
+
+func (a addrRange) containsRange(b addrRange) bool {
+	if a.len() == 0 || b.len() == 0 {
+		return false
+	}
+	return a.min <= b.min && a.max >= b.max
+}
+
+func (a *addrRange) extendToFit(x uint64) {
+	if x < a.min {
+		a.min = x
+	}
+	if x > a.max {
+		a.max = x
+	}
+}
+
+func (a *addrRange) insert(b addrRange) {
+	if b.len() == 0 {
+		return
+	}
+	if b.min < a.min {
+		a.min = b.min
+	}
+	if b.max > a.max {
+		a.max = b.max
+	}
+}

--- a/pkg/sbf/loader/copy.go
+++ b/pkg/sbf/loader/copy.go
@@ -1,0 +1,129 @@
+package loader
+
+import (
+	"debug/elf"
+	"fmt"
+	"io"
+)
+
+// The following ELF loading rules seem mostly arbitrary.
+// For the sake of cleanliness, this loader doesn't process
+// some badly malformed ELFs that would pass on Solana mainnet.
+// The Solana protocol is being improved in this area.
+
+// copy allocates program buffers and copies ELF contents.
+func (l *Loader) copy() error {
+	l.progRange = newAddrRange()
+	l.rodatas = make([]addrRange, 0, 4)
+	if err := l.getText(); err != nil {
+		return err
+	}
+	if err := l.mapSections(); err != nil {
+		return err
+	}
+	if err := l.copySections(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getText remembers the range of .text in the program buffer
+func (l *Loader) getText() error {
+	if err := l.checkSectionAddrs(l.shText); err != nil {
+		return fmt.Errorf("invalid .text: %w", err)
+	}
+	l.text = addrRange{min: l.shText.Off, max: l.shText.Off + l.shText.Size}
+	return nil
+}
+
+// mapRodataLike reserves ranges for sections in the program buffer
+func (l *Loader) mapSections() error {
+	// Walk all non-standard rodata sections
+	iter := l.newShTableIter()
+	for iter.Next() && iter.Err() == nil {
+		i, sh := iter.Index(), iter.Item()
+
+		// Skip standard sections
+		sectionName, err := l.getString(&l.shShstrtab, sh.Name, maxSectionNameLen)
+		if err != nil {
+			return fmt.Errorf("getString: %w", err)
+		}
+		switch sectionName {
+		case ".text", ".rodata", ".data.rel.ro", ".eh_frame":
+			// ok
+		default:
+			continue
+		}
+
+		if err := l.checkSectionAddrs(&sh); err != nil {
+			return fmt.Errorf("invalid rodata-like section %d: %w", i, err)
+		}
+
+		// Section overlap check & bounds tracking
+		section := addrRange{min: sh.Off, max: sh.Off + sh.Size}
+		if section.len() == 0 {
+			continue
+		}
+		if l.progRange.containsRange(section) {
+			// TODO rbpf probably doesn't have this restriction
+			return fmt.Errorf("rodata section %d overlaps with other section", i)
+		}
+		l.progRange.insert(section)
+
+		if section.min != l.text.min {
+			l.rodatas = append(l.rodatas, section)
+		}
+	}
+	return iter.Err()
+}
+
+func (l *Loader) checkSectionAddrs(sh *elf.Section64) error {
+	// TODO Support true vaddr ELFs
+
+	if sh.Size > l.fileSize {
+		return io.ErrUnexpectedEOF
+	}
+	if sh.Addr != sh.Off {
+		return fmt.Errorf("section physical address out-of-place")
+	}
+
+	// Ensure section within VM program range
+	vaddr := clampAddUint64(VaddrProgram, sh.Addr)
+	vaddrEnd := vaddr + sh.Size
+	if vaddrEnd < vaddr || vaddrEnd > VaddrStack {
+		return fmt.Errorf("section virtual address out-of-bounds")
+	}
+
+	return nil
+}
+
+// copySections copies text and rodata-like sections from the ELF into VM memory.
+func (l *Loader) copySections() error {
+	if l.progRange.len() == 0 {
+		// TODO what is the correct behavior here?
+		return fmt.Errorf("program is empty (???)")
+	}
+	l.progRange.extendToFit(0)
+
+	// Allocate!
+	l.program = make([]byte, l.progRange.len())
+
+	// Read data from ELF file
+	for _, section := range l.rodatas {
+		if err := l.copySection(section); err != nil {
+			return err
+		}
+	}
+	if err := l.copySection(l.text); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *Loader) copySection(section addrRange) (err error) {
+	off, size := int64(section.min), int64(section.len())
+	rd := io.NewSectionReader(l.rd, off, size)
+	_, err = io.ReadFull(rd, l.program[section.min:section.max])
+	return
+}

--- a/pkg/sbf/loader/loader.go
+++ b/pkg/sbf/loader/loader.go
@@ -1,0 +1,95 @@
+package loader
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"io"
+
+	"github.com/certusone/radiance/pkg/sbf"
+)
+
+// Loader is based on solana_rbpf::elf_parser
+type Loader struct {
+	// File containing ELF
+	rd       io.ReaderAt
+	fileSize uint64
+
+	// ELF data structures
+	eh         elf.Header64
+	phLoad     elf.Prog64
+	phDynamic  *elf.Prog64
+	shShstrtab elf.Section64
+	shText     *elf.Section64
+	shSymtab   *elf.Section64
+	shStrtab   *elf.Section64
+	shDynstr   *elf.Section64
+	shDynamic  *elf.Section64
+	dynamic    [DT_NUM]uint64
+	relocsIter *tableIter[elf.Rel64]
+	dynSymIter *tableIter[elf.Sym64]
+
+	// Program section/segment mappings
+	// Uses physical addressing
+	rodatas   []addrRange
+	text      addrRange
+	progRange addrRange
+
+	// Contains most of ELF (.text and rodata-like)
+	// Non-loaded sections are zeroed
+	program []byte
+
+	// Symbols
+	//funcs    map[uint32]symbol
+	//syscalls map[uint32]string
+}
+
+// Bounds checks
+const (
+	// 64 MiB max program size.
+	// Allows loader to use unchecked math when adding 32-bit offsets.
+	maxFileLen = 1 << 26
+
+	maxSectionNameLen = 16
+	maxSymbolNameLen  = 1024
+)
+
+// EF_SBF_V2 is the SBFv2 ELF flag
+const EF_SBF_V2 = 0x20
+
+// DT_NUM is the number of ELF generic dynamic entry types
+const DT_NUM = 35
+
+// Hardcoded addresses.
+const (
+	VaddrProgram = uint64(0x1_0000_0000)
+	VaddrStack   = uint64(0x2_0000_0000)
+	VaddrHeap    = uint64(0x3_0000_0000)
+	VaddrInput   = uint64(0x4_0000_0000)
+)
+
+// NewLoaderFromBytes creates an ELF loader from a byte slice.
+func NewLoaderFromBytes(buf []byte) (*Loader, error) {
+	if len(buf) > maxFileLen {
+		return nil, fmt.Errorf("ELF file too large")
+	}
+	l := &Loader{
+		rd:       bytes.NewReader(buf),
+		fileSize: uint64(len(buf)),
+	}
+	return l, nil
+}
+
+// Load parses, loads, and relocates an SBF program.
+func (l *Loader) Load() (*sbf.Program, error) {
+	if err := l.parse(); err != nil {
+		return nil, err
+	}
+	if err := l.copy(); err != nil {
+		return nil, err
+	}
+	//if err := l.relocate(); err != nil {
+	//	return nil, err
+	//}
+	panic("unimplemented")
+}

--- a/pkg/sbf/loader/loader_test.go
+++ b/pkg/sbf/loader/loader_test.go
@@ -63,6 +63,16 @@ func TestLoadProgram_Noop(t *testing.T) {
 	}, loader.shShstrtab)
 
 	assert.Equal(t, &elf.Section64{
+		Name:      50,
+		Type:      uint32(elf.SHT_PROGBITS),
+		Flags:     6,
+		Addr:      4096,
+		Off:       4096,
+		Size:      96,
+		Addralign: 8,
+	}, loader.shText)
+
+	assert.Equal(t, &elf.Section64{
 		Name:      74,
 		Type:      uint32(elf.SHT_SYMTAB),
 		Flags:     0,

--- a/pkg/sbf/loader/parse.go
+++ b/pkg/sbf/loader/parse.go
@@ -41,6 +41,7 @@ type loader struct {
 	phLoad     elf.Prog64
 	phDynamic  *elf.Prog64
 	shShstrtab elf.Section64
+	shText     *elf.Section64
 	shSymtab   *elf.Section64
 	shStrtab   *elf.Section64
 	shDynstr   *elf.Section64
@@ -295,6 +296,8 @@ func (l *loader) parseSections() error {
 			return nil
 		}
 		switch sectionName {
+		case ".text":
+			err = setSection(&l.shText)
 		case ".symtab":
 			err = setSection(&l.shSymtab)
 		case ".strtab":

--- a/pkg/sbf/program.go
+++ b/pkg/sbf/program.go
@@ -1,0 +1,5 @@
+package sbf
+
+// Program is a loaded SBF program.
+type Program struct {
+}


### PR DESCRIPTION
Implements most of the segment/section handling of the ELF loader (excluding relocations).
The loader can now parse and load mainnet-ready Solana on-chain ELFs.

Support for badly malformed ELFs and vaddr-aware ELFs is deliberately left out.

- sbf: rename loader.go -> parse.go
- sbf: add section loader
